### PR TITLE
centos_7: build dpdk library from sources

### DIFF
--- a/centos_7/Dockerfile
+++ b/centos_7/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:7
 
+ENV DPDK_VERSION=18.11 \
+    RTE_ARCH=x86_64 \
+    RTE_TARGET=x86_64-native-linuxapp-gcc
+
 RUN yum update -y
 
 RUN yum install -y \
@@ -12,8 +16,6 @@ RUN yum install -y \
 	CUnit-devel \
 	curl \
 	doxygen \
-	dpdk \
-	dpdk-devel \
 	gcc \
 	gcc-c++ \
 	git-core \
@@ -21,9 +23,25 @@ RUN yum install -y \
 	kmod \
 	libatomic \
 	libconfig-devel \
+	libpcap-devel \
 	libtool \
 	make \
+	numactl-devel \
 	net-tools \
 	openssl-devel \
 	pkgconfig \
 	sudo
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    make config T=x86_64-native-linuxapp-gcc O=x86_64-native-linuxapp-gcc && \
+    cd x86_64-native-linuxapp-gcc/ && \
+    sed -ri 's,(CONFIG_RTE_MACHINE=).*,\1"default",' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_EAL_IGB_UIO=).*,\1n,' .config && \
+    sed -ri 's,(CONFIG_RTE_KNI_KMOD=).*,\1n,' .config && \
+    cd .. && \
+    make -j $(nproc) install T=x86_64-native-linuxapp-gcc DESTDIR=/usr EXTRA_CFLAGS="-fPIC" && \
+    cd -


### PR DESCRIPTION
CentOS 7 DPDK package is missing some required libraries (e.g. crypto), so
DPDK has to be built manually from sources.

Signed-off-by: Matias Elo <matias.elo@nokia.com>