### PR TITLE
ubuntu_18.04: build dpdk library from sources

### DIFF
--- a/ubuntu_18.04/Dockerfile
+++ b/ubuntu_18.04/Dockerfile
@@ -1,15 +1,15 @@
 FROM ubuntu:18.04
 
+ENV DPDK_VERSION=17.11 \
+	RTE_ARCH=x86_64 \
+	RTE_TARGET=x86_64-native-linuxapp-gcc
+
 RUN apt-get update
 
 RUN apt-get install -yy --no-install-recommends \
         software-properties-common \
 	dirmngr \
 	gnupg-agent
-
-RUN sed -e 's/^deb http/deb [arch=amd64,i386] http/g' /etc/apt/sources.list -i
-RUN echo deb http://ppa.launchpad.net/lumag/odp-xenial/ubuntu xenial main > /etc/apt/sources.list.d/lumag-ppa.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 41E0C15904CF4B2F
 
 RUN apt-get update --fix-missing
 
@@ -35,7 +35,20 @@ RUN apt-get install -yy \
   xsltproc \
   git \
   iproute2 \
-  libdpdk-dev:amd64 \
   libibverbs-dev \
   python-pip && \
 pip install coverage
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    make config T=x86_64-native-linuxapp-gcc O=x86_64-native-linuxapp-gcc && \
+    cd x86_64-native-linuxapp-gcc/ && \
+    sed -ri 's,(CONFIG_RTE_MACHINE=).*,\1"default",' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_EAL_IGB_UIO=).*,\1n,' .config && \
+    sed -ri 's,(CONFIG_RTE_KNI_KMOD=).*,\1n,' .config && \
+    cd .. && \
+    make -j $(nproc) install T=x86_64-native-linuxapp-gcc DESTDIR=/usr EXTRA_CFLAGS="-fPIC" && \
+    cd -


### PR DESCRIPTION
Latest Ubuntu DPDK package is missing some required libraries (e.g.
crypto), so DPDK has to be built manually from sources.

Signed-off-by: Matias Elo <matias.elo@nokia.com>