### PR TITLE
ubuntu_20.04: build dpdk manually

### DIFF
--- a/ubuntu_20.04-x86_64/Dockerfile
+++ b/ubuntu_20.04-x86_64/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:20.04
 
+ENV DPDK_VERSION=18.11 \
+	RTE_ARCH=x86_64 \
+	RTE_TARGET=x86_64-native-linuxapp-gcc
+
 RUN apt-get update
 
 RUN apt-get install -yy --no-install-recommends \
@@ -15,7 +19,6 @@ RUN apt-get install -yy \
   automake \
   ccache \
   clang \
-  dpdk-dev \
   gcc \
   git \
   graphviz \
@@ -35,3 +38,17 @@ RUN apt-get install -yy \
   sudo \
   xsltproc && \
 pip install coverage
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    make config T=${RTE_TARGET} O=${RTE_TARGET} && \
+    cd ${RTE_TARGET} && \
+    sed -ri 's,(CONFIG_RTE_MACHINE=).*,\1"default",' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_EAL_IGB_UIO=).*,\1n,' .config && \
+    sed -ri 's,(CONFIG_RTE_KNI_KMOD=).*,\1n,' .config && \
+    cd .. && \
+    make -j $(nproc) install T=${RTE_TARGET} DESTDIR=/usr EXTRA_CFLAGS="-fPIC" && \
+    cd -


### PR DESCRIPTION
Fixes linking (GCC 9.2) getting stuck in Travis when building ODP with DPDK
pktio.

Signed-off-by: Matias Elo <matias.elo@nokia.com>