### PR TITLE
ubuntu_18.04: add curl

### DIFF
--- a/ubuntu_18.04-x86_64/Dockerfile
+++ b/ubuntu_18.04-x86_64/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get install -yy \
   automake \
   ccache \
   clang \
+  curl \
   gcc \
   git \
   graphviz \


### PR DESCRIPTION
Curl is required by Codecov coverage test.

Signed-off-by: Matias Elo <matias.elo@nokia.com>