### PR TITLE
ubuntu_20.04: fix clang build

### DIFF
--- a/ubuntu_20.04-arm64/Dockerfile
+++ b/ubuntu_20.04-arm64/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get install -y \
   libcunit1-dev:arm64 \
   libpcap-dev:arm64 \
   libssl-dev:arm64 \
-  libstdc++-9-dev:arm64 \
+  libstdc++-10-dev:arm64 \
   pkg-config-aarch64-linux-gnu \
   asciidoctor \
   autoconf \

--- a/ubuntu_20.04-x86_64/Dockerfile
+++ b/ubuntu_20.04-x86_64/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get install -yy \
   libnuma-dev \
   libpcap-dev \
   libssl-dev \
+  libstdc++-10-dev \
   libtool \
   mscgen \
   net-tools \


### PR DESCRIPTION
Add missing iostream dependency.

Signed-off-by: Matias Elo <matias.elo@nokia.com>