### PR TITLE
centos_8: add diffutils dependency

### DIFF
--- a/centos_8-x86_64/Dockerfile
+++ b/centos_8-x86_64/Dockerfile
@@ -18,6 +18,7 @@ RUN yum install -y \
 	clang \
 	CUnit-devel \
 	curl \
+	diffutils \
 	doxygen \
 	gcc \
 	gcc-c++ \


### PR DESCRIPTION
DPDK build requires cmp tool which is provided by diffutils package.

Signed-off-by: Matias Elo <matias.elo@nokia.com>