### PR TITLE
add libcli

### DIFF
--- a/centos_7-x86_64/Dockerfile
+++ b/centos_7-x86_64/Dockerfile
@@ -22,6 +22,7 @@ RUN yum install -y \
 	graphviz \
 	kmod \
 	libatomic \
+	libcli-devel \
 	libconfig-devel \
 	libpcap-devel \
 	libtool \

--- a/ubuntu_18.04-arm64/Dockerfile
+++ b/ubuntu_18.04-arm64/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update --fix-missing
 
 RUN apt-get install -yy \
   crossbuild-essential-arm64 \
+  libcli-dev:arm64 \
   libconfig-dev:arm64 \
   libcunit1-dev:arm64 \
   libdpdk-dev:arm64 \

--- a/ubuntu_18.04-armhf/Dockerfile
+++ b/ubuntu_18.04-armhf/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update --fix-missing
 
 RUN apt-get install -yy \
   crossbuild-essential-armhf \
+  libcli-dev:armhf \
   libconfig-dev:armhf \
   libcunit1-dev:armhf \
   libpcap-dev:armhf \

--- a/ubuntu_18.04-i386/Dockerfile
+++ b/ubuntu_18.04-i386/Dockerfile
@@ -14,6 +14,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update --fix-missing
 
 RUN apt-get install -yy \
+  libcli-dev:i386 \
   libconfig-dev:i386 \
   libcunit1-dev:i386 \
   libdpdk-dev:i386 \

--- a/ubuntu_18.04-ppc64el/Dockerfile
+++ b/ubuntu_18.04-ppc64el/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update --fix-missing
 
 RUN apt-get install -yy \
   crossbuild-essential-ppc64el \
+  libcli-dev:ppc64el \
   libconfig-dev:ppc64el \
   libcunit1-dev:ppc64el \
   libdpdk-dev:ppc64el \

--- a/ubuntu_18.04-x86_64-dpdk_18.11/Dockerfile
+++ b/ubuntu_18.04-x86_64-dpdk_18.11/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get install -yy \
   graphviz \
   iproute2 \
   kmod \
+  libcli-dev \
   libconfig-dev \
   libcunit1-dev \
   libibverbs-dev \

--- a/ubuntu_18.04-x86_64-dpdk_19.11/Dockerfile
+++ b/ubuntu_18.04-x86_64-dpdk_19.11/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get install -yy \
   graphviz \
   iproute2 \
   kmod \
+  libcli-dev \
   libconfig-dev \
   libcunit1-dev \
   libibverbs-dev \

--- a/ubuntu_18.04-x86_64/Dockerfile
+++ b/ubuntu_18.04-x86_64/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get install -yy \
   graphviz \
   iproute2 \
   kmod \
+  libcli-dev \
   libconfig-dev \
   libcunit1-dev \
   libibverbs-dev \

--- a/ubuntu_20.04-arm64/Dockerfile
+++ b/ubuntu_20.04-arm64/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get install -o APT::Immediate-Configure=false -y \
 
 RUN apt-get install -y \
   crossbuild-essential-arm64 \
+  libcli-dev:arm64 \
   libconfig-dev:arm64 \
   libcunit1-dev:arm64 \
   libpcap-dev:arm64 \

--- a/ubuntu_20.04-riscv64/Dockerfile
+++ b/ubuntu_20.04-riscv64/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get install -o APT::Immediate-Configure=false -y \
 
 RUN apt-get install -y \
   crossbuild-essential-riscv64 \
+  libcli-dev:riscv64 \
   libconfig-dev:riscv64 \
   libcunit1-dev:riscv64 \
   libpcap-dev:riscv64 \

--- a/ubuntu_20.04-x86_64/Dockerfile
+++ b/ubuntu_20.04-x86_64/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get install -yy \
   graphviz \
   iproute2 \
   kmod \
+  libcli-dev \
   libconfig-dev \
   libcunit1-dev \
   libibverbs-dev \


### PR DESCRIPTION
```
Add libcli-dev (or libcli-devel), used by ODP CLI helper, to all
images currently in use.

Signed-off-by: Jere Leppänen <jere.leppanen@nokia.com>
```
