### PR TITLE
github_actions: add Coverity job and Dockerfile

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -22,13 +22,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ['ubuntu_16.04-x86_64', 'ubuntu_18.04-arm64', 'ubuntu_18.04-armhf', 'ubuntu_18.04-i386', 'ubuntu_18.04-ppc64el', 'ubuntu_18.04-x86_64', 'ubuntu_18.04-x86_64-dpdk_18.11', 'ubuntu_20.04-arm64', 'ubuntu_20.04-riscv64', 'ubuntu_20.04-x86_64', 'ubuntu_20.04-x86_64-dpdk_20.11', 'centos_7-x86_64', 'centos_8-x86_64']
+        image: ['ubuntu_16.04-x86_64', 'ubuntu_18.04-arm64', 'ubuntu_18.04-armhf', 'ubuntu_18.04-i386', 'ubuntu_18.04-ppc64el', 'ubuntu_18.04-x86_64', 'ubuntu_18.04-x86_64-dpdk_18.11', 'ubuntu_20.04-arm64', 'ubuntu_20.04-riscv64', 'ubuntu_20.04-x86_64', 'ubuntu_20.04-x86_64-coverity-linux-generic', 'ubuntu_20.04-x86_64-dpdk_20.11', 'centos_7-x86_64', 'centos_8-x86_64']
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build $IMAGE_DIR -t $IMAGE_NAME
+        run: docker build --build-arg COVERITY_TOKEN=${{ secrets.COVERITY_TOKEN }} $IMAGE_DIR -t $IMAGE_NAME
 
       - name: Log into registry
         if: github.event_name == 'push'

--- a/ubuntu_20.04-x86_64-coverity-linux-generic/Dockerfile
+++ b/ubuntu_20.04-x86_64-coverity-linux-generic/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:20.04
+
+ARG COVERITY_TOKEN
+
+ENV COVERITY_PROJECT=ODP
+
+RUN apt-get update
+
+RUN apt-get install -yy --no-install-recommends \
+  software-properties-common \
+  dirmngr \
+  gnupg-agent
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -yy \
+  autoconf \
+  automake \
+  ccache \
+  clang \
+  curl \
+  gcc \
+  gcc-10 \
+  git \
+  libcli-dev \
+  libconfig-dev \
+  libcunit1-dev \
+  libpcap-dev \
+  libssl-dev \
+  libtool \
+  libstdc++-10-dev \
+  make \
+  sudo
+
+RUN curl -d "token=${COVERITY_TOKEN}&project=${COVERITY_PROJECT}" -o /coverity_tool.tgz https://scan.coverity.com/download/linux64 && \
+  mkdir /coverity_tool && \
+  tar xf /coverity_tool.tgz --strip 1 -C /coverity_tool
+
+ENV PATH="${PATH}:/coverity_tool/bin"


### PR DESCRIPTION
Since Coverity is a static analysis tool, it doesn't require a multitude
of different builds to be analyzed, so add just one job.
Add a Dockerfile with only the necessary packages for a non-DPDK build
and the ability to download Coverity.

Signed-off-by: Juraj Linkeš <juraj.linkes@pantheon.tech>