### PR TITLE
Adding support for Arm64 containers

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -14,7 +14,7 @@ on:
   pull_request:
 
 jobs:
-  Build:
+  Build_x86_64:
     runs-on: ubuntu-18.04
     env:
       IMAGE_DIR: ${{matrix.image}}
@@ -23,6 +23,50 @@ jobs:
       fail-fast: false
       matrix:
         image: ['ubuntu_16.04-x86_64', 'ubuntu_18.04-arm64', 'ubuntu_18.04-armhf', 'ubuntu_18.04-i386', 'ubuntu_18.04-ppc64el', 'ubuntu_18.04-x86_64', 'ubuntu_18.04-x86_64-dpdk_18.11', 'ubuntu_20.04-arm64', 'ubuntu_20.04-riscv64', 'ubuntu_20.04-x86_64', 'ubuntu_20.04-x86_64-coverity-linux-generic', 'ubuntu_20.04-x86_64-dpdk_20.11', 'centos_7-x86_64', 'centos_8-x86_64']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build --build-arg COVERITY_TOKEN=${{ secrets.COVERITY_TOKEN }} $IMAGE_DIR -t $IMAGE_NAME
+
+      - name: Log into registry
+        if: github.event_name == 'push'
+        run: echo "${{ secrets.CONTAINER_REGISTRY_TOKEN }}" | docker login ghcr.io -u ${{ secrets.CONTAINER_REGISTRY_USER }} --password-stdin
+
+      - name: Push image
+        if: github.event_name == 'push'
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+
+  Build_arm64:
+    # Ensuring CI is only run on repo where self-hosted runners are installed
+    if: ${{ github.repository == 'OpenDataPlane/odp-docker-images' }}
+    runs-on: self-hosted
+    env:
+      IMAGE_DIR: ${{matrix.image}}
+      IMAGE_NAME: odp-ci-${{matrix.image}}
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ['ubuntu_16.04-arm64-native', 'ubuntu_18.04-arm64-native',
+                'ubuntu_18.04-arm64-native-dpdk_18.11', 'ubuntu_20.04-arm64-native',
+                'centos_8-arm64-native']
 
     steps:
       - uses: actions/checkout@v2

--- a/centos_8-arm64-native/Dockerfile
+++ b/centos_8-arm64-native/Dockerfile
@@ -1,0 +1,50 @@
+FROM centos:8
+
+ENV DPDK_VERSION=v19.11.6 \
+    RTE_ARCH=arm64 \
+    RTE_TARGET=arm64-armv8a-linuxapp-gcc
+
+RUN dnf install -y 'dnf-command(config-manager)'
+RUN dnf config-manager --set-enabled powertools
+
+RUN yum update -y
+
+RUN yum install -y \
+	https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+RUN yum install -y \
+	autoconf \
+	automake \
+	clang \
+	CUnit-devel \
+	curl \
+	diffutils \
+	doxygen \
+	gcc \
+	gcc-c++ \
+	git-core \
+	graphviz \
+	kmod \
+	libatomic \
+	libconfig-devel \
+	libpcap-devel \
+	libtool \
+	make \
+	numactl-devel \
+	net-tools \
+	openssl-devel \
+	pkgconfig \
+	sudo
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    make config T=${RTE_TARGET} O=${RTE_TARGET} && \
+    cd ${RTE_TARGET} && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_EAL_IGB_UIO=).*,\1n,' .config && \
+    sed -ri 's,(CONFIG_RTE_KNI_KMOD=).*,\1n,' .config && \
+    cd .. && \
+    make -j $(nproc) install T=${RTE_TARGET} DESTDIR=/usr EXTRA_CFLAGS="-fPIC" && \
+    cd -

--- a/ubuntu_16.04-arm64-native/Dockerfile
+++ b/ubuntu_16.04-arm64-native/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:16.04
+
+ENV DPDK_VERSION=v19.11.6 \
+    RTE_ARCH=arm64 \
+    RTE_TARGET=arm64-armv8a-linuxapp-gcc
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -yy --no-install-recommends \
+	software-properties-common
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -yy --no-install-recommends \
+	asciidoctor \
+	autoconf \
+	automake \
+	build-essential \
+	ccache \
+	clang \
+	doxygen \
+	git-core \
+	graphviz \
+	iproute2 \
+	libconfig-dev \
+	libcunit1-dev \
+	libnuma-dev \
+	libpcap0.8-dev \
+	libssl-dev \
+	libtool \
+	net-tools \
+	mscgen \
+	pkg-config \
+	python-pip \
+	sudo \
+	xsltproc
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    make config T=${RTE_TARGET} O=${RTE_TARGET} && \
+    cd ${RTE_TARGET} && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_EAL_IGB_UIO=).*,\1n,' .config && \
+    sed -ri 's,(CONFIG_RTE_KNI_KMOD=).*,\1n,' .config && \
+    cd .. && \
+    make -j $(nproc) install T=${RTE_TARGET} DESTDIR=/usr EXTRA_CFLAGS="-fPIC" && \
+    cd -

--- a/ubuntu_18.04-arm64-native-dpdk_18.11/Dockerfile
+++ b/ubuntu_18.04-arm64-native-dpdk_18.11/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:18.04
+
+ENV DPDK_VERSION=v18.11.11 \
+	RTE_ARCH=arm64 \
+	RTE_TARGET=arm64-armv8a-linuxapp-gcc
+
+RUN apt-get update
+
+RUN apt-get install -yy --no-install-recommends \
+        software-properties-common \
+	dirmngr \
+	gnupg-agent
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -yy \
+  asciidoctor \
+  autoconf \
+  automake \
+  ccache \
+  clang \
+  gcc \
+  git \
+  graphviz \
+  iproute2 \
+  kmod \
+  libcli-dev \
+  libconfig-dev \
+  libcunit1-dev \
+  libibverbs-dev \
+  libnuma-dev \
+  libpcap-dev \
+  libssl-dev \
+  libtool \
+  mscgen \
+  net-tools \
+  python-pip \
+  ruby-dev \
+  sudo \
+  xsltproc && \
+pip install coverage
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    make config T=${RTE_TARGET} O=${RTE_TARGET} && \
+    cd ${RTE_TARGET} && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_EAL_IGB_UIO=).*,\1n,' .config && \
+    sed -ri 's,(CONFIG_RTE_KNI_KMOD=).*,\1n,' .config && \
+    cd .. && \
+    make -j $(nproc) install T=${RTE_TARGET} DESTDIR=/usr EXTRA_CFLAGS="-fPIC" && \
+    cd -

--- a/ubuntu_18.04-arm64-native/Dockerfile
+++ b/ubuntu_18.04-arm64-native/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:18.04
+
+ENV DPDK_VERSION=v19.11.6 \
+	RTE_ARCH=arm64 \
+	RTE_TARGET=arm64-armv8a-linuxapp-gcc
+
+RUN apt-get update
+
+RUN apt-get install -yy --no-install-recommends \
+        software-properties-common \
+	dirmngr \
+	gnupg-agent
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -yy \
+  asciidoctor \
+  autoconf \
+  automake \
+  ccache \
+  clang \
+  curl \
+  gcc \
+  git \
+  graphviz \
+  iproute2 \
+  kmod \
+  libcli-dev \
+  libconfig-dev \
+  libcunit1-dev \
+  libibverbs-dev \
+  libnuma-dev \
+  libpcap-dev \
+  libssl-dev \
+  libtool \
+  mscgen \
+  net-tools \
+  python-pip \
+  ruby-dev \
+  sudo \
+  xsltproc && \
+pip install coverage
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    make config T=${RTE_TARGET} O=${RTE_TARGET} && \
+    cd ${RTE_TARGET} && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_EAL_IGB_UIO=).*,\1n,' .config && \
+    sed -ri 's,(CONFIG_RTE_KNI_KMOD=).*,\1n,' .config && \
+    cd .. && \
+    make -j $(nproc) install T=${RTE_TARGET} DESTDIR=/usr EXTRA_CFLAGS="-fPIC" && \
+    cd -

--- a/ubuntu_20.04-arm64-native/Dockerfile
+++ b/ubuntu_20.04-arm64-native/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:20.04
+
+ENV DPDK_VERSION=v19.11.6 \
+	RTE_ARCH=arm64 \
+	RTE_TARGET=arm64-armv8a-linuxapp-gcc
+
+RUN apt-get update
+
+RUN apt-get install -yy --no-install-recommends \
+        software-properties-common \
+	dirmngr \
+	gnupg-agent
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -yy \
+  asciidoctor \
+  autoconf \
+  automake \
+  ccache \
+  clang \
+  gcc \
+  gcc-10 \
+  git \
+  graphviz \
+  iproute2 \
+  kmod \
+  libcli-dev \
+  libconfig-dev \
+  libcunit1-dev \
+  libibverbs-dev \
+  libnuma-dev \
+  libpcap-dev \
+  libssl-dev \
+  libstdc++-10-dev \
+  libtool \
+  mscgen \
+  net-tools \
+  python3-pip \
+  ruby-dev \
+  sudo \
+  xsltproc && \
+pip3 install coverage
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    make config T=${RTE_TARGET} O=${RTE_TARGET} && \
+    cd ${RTE_TARGET} && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config && \
+    sed -ri 's,(CONFIG_RTE_EAL_IGB_UIO=).*,\1n,' .config && \
+    sed -ri 's,(CONFIG_RTE_KNI_KMOD=).*,\1n,' .config && \
+    cd .. && \
+    make -j $(nproc) install T=${RTE_TARGET} DESTDIR=/usr EXTRA_CFLAGS="-fPIC" && \
+    cd -


### PR DESCRIPTION
  - Updating CI to build on Graviton2 self hosted runners
  - Adding Dockerfiles for Ubuntu and CentOS

Jobs have been restricticted to only run when repo is owned by the
OpenDataPlane organisation. This is to prevent the CI triggering on
forks of the project where Graviton2 self-hosted runners are not
available.