### PR TITLE
remove OPT compiler flag for AArch64cryptolib

### DIFF
--- a/centos_8-arm64-native/Dockerfile
+++ b/centos_8-arm64-native/Dockerfile
@@ -53,5 +53,5 @@ RUN cd $HOME && \
 RUN cd $HOME && \
     git clone https://github.com/ARM-software/AArch64cryptolib --depth 1 ./aarch64cryptolib && \
     cd aarch64cryptolib && \
-    OPT=big make && \
+    make && \
     cd -

--- a/ubuntu_16.04-arm64-native/Dockerfile
+++ b/ubuntu_16.04-arm64-native/Dockerfile
@@ -51,5 +51,5 @@ RUN cd $HOME && \
 RUN cd $HOME && \
     git clone https://github.com/ARM-software/AArch64cryptolib --depth 1 ./aarch64cryptolib && \
     cd aarch64cryptolib && \
-    OPT=big make && \
+    make && \
     cd -

--- a/ubuntu_18.04-arm64-native-dpdk_18.11/Dockerfile
+++ b/ubuntu_18.04-arm64-native-dpdk_18.11/Dockerfile
@@ -56,5 +56,5 @@ RUN cd $HOME && \
 RUN cd $HOME && \
     git clone https://github.com/ARM-software/AArch64cryptolib --depth 1 ./aarch64cryptolib && \
     cd aarch64cryptolib && \
-    OPT=big make && \
+    make && \
     cd -

--- a/ubuntu_18.04-arm64-native/Dockerfile
+++ b/ubuntu_18.04-arm64-native/Dockerfile
@@ -57,5 +57,5 @@ RUN cd $HOME && \
 RUN cd $HOME && \
     git clone https://github.com/ARM-software/AArch64cryptolib --depth 1 ./aarch64cryptolib && \
     cd aarch64cryptolib && \
-    OPT=big make && \
+    make && \
     cd -

--- a/ubuntu_20.04-arm64-native-dpdk_20.11/Dockerfile
+++ b/ubuntu_20.04-arm64-native-dpdk_20.11/Dockerfile
@@ -54,5 +54,5 @@ RUN cd $HOME && \
 RUN cd $HOME && \
     git clone https://github.com/ARM-software/AArch64cryptolib --depth 1 ./aarch64cryptolib && \
     cd aarch64cryptolib && \
-    OPT=big make && \
+    make && \
     cd -

--- a/ubuntu_20.04-arm64-native/Dockerfile
+++ b/ubuntu_20.04-arm64-native/Dockerfile
@@ -58,5 +58,5 @@ RUN cd $HOME && \
 RUN cd $HOME && \
     git clone https://github.com/ARM-software/AArch64cryptolib --depth 1 ./aarch64cryptolib && \
     cd aarch64cryptolib && \
-    OPT=big make && \
+    make && \
     cd -


### PR DESCRIPTION
Use of the OPT=big compiler flag when building the AArch64cryptolib
results in stack smashing errors for the native CI jobs for Armv8 crypto.
This flag can be removed and AArch64cryptolib can detect the CPU
implementation during the build.

Signed-off-by: Malvika Gupta <Malvika.Gupta@arm.com>