### PR TITLE
rocky_8: install procps package

### DIFF
--- a/rocky_linux_8-arm64-native/Dockerfile
+++ b/rocky_linux_8-arm64-native/Dockerfile
@@ -35,6 +35,7 @@ RUN yum install -y \
 	net-tools \
 	openssl-devel \
 	pkgconfig \
+	procps \
 	sudo
 
 RUN cd $HOME && \

--- a/rocky_linux_8-x86_64/Dockerfile
+++ b/rocky_linux_8-x86_64/Dockerfile
@@ -34,6 +34,7 @@ RUN yum install -y \
 	net-tools \
 	openssl-devel \
 	pkgconfig \
+	procps \
 	sudo
 
 RUN cd $HOME && \


### PR DESCRIPTION
Install procps package, which includes sysctl tool required by ODP-DPDK CI.

Signed-off-by: Matias Elo <matias.elo@nokia.com>