### PR TITLE
ubuntu_22.04: add containers with manually built openssl

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -36,6 +36,7 @@ jobs:
                 'ubuntu_20.04-x86_64-dpdk_20.11',
                 'ubuntu_20.04-x86_64-dpdk_21.11',
                 'ubuntu_22.04-x86_64',
+                'ubuntu_22.04-openssl-x86_64',
                 'centos_7-x86_64',
                 'rocky_linux_8-x86_64']
 
@@ -85,6 +86,7 @@ jobs:
                 'ubuntu_20.04-arm64-native-dpdk_20.11',
                 'ubuntu_20.04-arm64-native-dpdk_21.11',
                 'ubuntu_22.04-arm64-native',
+                'ubuntu_22.04-openssl-arm64-native',
                 'rocky_linux_8-arm64-native']
 
     steps:

--- a/ubuntu_22.04-openssl-arm64-native/Dockerfile
+++ b/ubuntu_22.04-openssl-arm64-native/Dockerfile
@@ -1,0 +1,79 @@
+FROM ubuntu:22.04
+
+ENV DPDK_VERSION=v20.11.5 \
+    OPENSSL_VERSION=OpenSSL_1_1_1o \
+    XDP_VERSION=v1.2.3
+
+RUN apt-get update
+
+RUN apt-get install -yy --no-install-recommends \
+        software-properties-common \
+	dirmngr \
+	gnupg-agent
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -yy \
+  asciidoctor \
+  autoconf \
+  automake \
+  ccache \
+  clang \
+  gcc \
+  git \
+  graphviz \
+  iproute2 \
+  kmod \
+  libbpf-dev \
+  libcli-dev \
+  libconfig-dev \
+  libcunit1-dev \
+  libibverbs-dev \
+  libnuma-dev \
+  libpcap-dev \
+  libstdc++-10-dev \
+  libtool \
+  llvm-dev \
+  meson \
+  mscgen \
+  net-tools \
+  ninja-build \
+  python3-pip \
+  ruby-dev \
+  sudo \
+  xsltproc && \
+pip3 install \
+  coverage \
+  pyelftools
+
+RUN cd $HOME && \
+    git clone https://github.com/openssl/openssl.git --branch ${OPENSSL_VERSION} --depth 1 ./openssl && \
+    cd openssl && \
+    ./config && \
+    make -j $(nproc) && \
+    make install && \
+    cd -
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    meson build && \
+    cd build && \
+    ninja && \
+    ninja install && \
+    cd -
+
+RUN cd $HOME && \
+    git clone https://github.com/ARM-software/AArch64cryptolib --depth 1 ./aarch64cryptolib && \
+    cd aarch64cryptolib && \
+    make && \
+    cd -
+
+RUN cd $HOME && \
+    git clone --recurse-submodules https://github.com/xdp-project/xdp-tools.git --branch ${XDP_VERSION} --depth 1 ./xdp && \
+    cd xdp && \
+    ./configure && \
+    C_INCLUDE_PATH=/usr/include/aarch64-linux-gnu/ make && \
+    make install && \
+    ldconfig /usr/local/lib/ && \
+    cd -

--- a/ubuntu_22.04-openssl-x86_64/Dockerfile
+++ b/ubuntu_22.04-openssl-x86_64/Dockerfile
@@ -1,0 +1,83 @@
+FROM ubuntu:22.04
+
+ENV DPDK_VERSION=v20.11.5 \
+    IPSEC_MB_VERSION=v1.1 \
+    OPENSSL_VERSION=OpenSSL_1_1_1o \
+    XDP_VERSION=v1.2.3
+
+RUN apt-get update
+
+RUN apt-get install -yy --no-install-recommends \
+        software-properties-common \
+	dirmngr \
+	gnupg-agent
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -yy \
+  asciidoctor \
+  autoconf \
+  automake \
+  ccache \
+  clang \
+  gcc \
+  gcc-multilib \
+  git \
+  graphviz \
+  iproute2 \
+  kmod \
+  libbpf-dev \
+  libconfig-dev \
+  libcunit1-dev \
+  libibverbs-dev \
+  libnuma-dev \
+  libpcap-dev \
+  libstdc++-10-dev \
+  libtool \
+  llvm-dev \
+  meson \
+  mscgen \
+  nasm \
+  net-tools \
+  ninja-build \
+  python3-pip \
+  ruby-dev \
+  sudo \
+  xsltproc && \
+pip3 install \
+  coverage \
+  pyelftools
+
+RUN cd $HOME && \
+    git clone https://github.com/intel/intel-ipsec-mb.git --branch ${IPSEC_MB_VERSION} --depth 1 ./ipsec-mb && \
+    cd ipsec-mb && \
+    make -j $(nproc) && \
+    make install && \
+    cd -
+
+RUN cd $HOME && \
+    git clone https://github.com/openssl/openssl.git --branch ${OPENSSL_VERSION} --depth 1 ./openssl && \
+    cd openssl && \
+    ./config && \
+    make -j $(nproc) && \
+    make install && \
+    cd -
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    meson build && \
+    cd build && \
+    meson configure -Dmachine=default && \
+    ninja && \
+    ninja install && \
+    cd -
+
+RUN cd $HOME && \
+    git clone --recurse-submodules https://github.com/xdp-project/xdp-tools.git --branch ${XDP_VERSION} --depth 1 ./xdp && \
+    cd xdp && \
+    ./configure && \
+    make && \
+    make install && \
+    ldconfig /usr/local/lib/ && \
+    cd -


### PR DESCRIPTION
DPDK OpenSSL PMD has currently compatibility issues with OpenSSL 3.0, so
install OpenSSL 1.1.1 manually.

Signed-off-by: Matias Elo <matias.elo@nokia.com>