### PR TITLE
ubuntu_18.04: add additional gcc versions for build test usage

### DIFF
--- a/ubuntu_18.04-x86_64/Dockerfile
+++ b/ubuntu_18.04-x86_64/Dockerfile
@@ -21,6 +21,8 @@ RUN apt-get install -yy \
   clang \
   curl \
   gcc \
+  gcc-7 \
+  gcc-8 \
   git \
   graphviz \
   iproute2 \
@@ -32,6 +34,8 @@ RUN apt-get install -yy \
   libnuma-dev \
   libpcap-dev \
   libssl-dev \
+  libstdc++-7-dev \
+  libstdc++-8-dev \
   libtool \
   mscgen \
   net-tools \


### PR DESCRIPTION
Signed-off-by: Matias Elo <matias.elo@nokia.com>