### PR TITLE
ubuntu_20.04: add build-essential package

### DIFF
--- a/ubuntu_20.04-arm64-native-dpdk_19.11/Dockerfile
+++ b/ubuntu_20.04-arm64-native-dpdk_19.11/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update --fix-missing
 RUN apt-get install -yy \
   autoconf \
   automake \
+  build-essential \
   ccache \
   clang \
   gcc \


### PR DESCRIPTION
Package required for DPDK 19.11 test.