### PR TITLE
dpdk: remove generic platform option from aarch64

### DIFF
--- a/rocky_linux_8-arm64-native/Dockerfile
+++ b/rocky_linux_8-arm64-native/Dockerfile
@@ -48,7 +48,6 @@ RUN cd $HOME && \
     cd dpdk && \
     meson setup build && \
     cd build && \
-    meson configure -Dplatform=generic && \
     meson configure -Ddisable_apps=* && \
     meson configure -Dtests=false && \
     meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \

--- a/rocky_linux_9-arm64-native/Dockerfile
+++ b/rocky_linux_9-arm64-native/Dockerfile
@@ -48,7 +48,6 @@ RUN cd $HOME && \
     cd dpdk && \
     meson setup build && \
     cd build && \
-    meson configure -Dplatform=generic && \
     meson configure -Ddisable_apps=* && \
     meson configure -Dtests=false && \
     meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \

--- a/ubuntu_18.04-arm64-native/Dockerfile
+++ b/ubuntu_18.04-arm64-native/Dockerfile
@@ -44,7 +44,6 @@ RUN cd $HOME && \
     cd dpdk && \
     meson setup build && \
     cd build && \
-    meson configure -Dplatform=generic && \
     meson configure -Ddisable_apps=* && \
     meson configure -Dtests=false && \
     meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \

--- a/ubuntu_20.04-arm64-native-dpdk_20.11/Dockerfile
+++ b/ubuntu_20.04-arm64-native-dpdk_20.11/Dockerfile
@@ -41,7 +41,6 @@ RUN cd $HOME && \
     cd dpdk && \
     meson setup build && \
     cd build && \
-    meson configure -Dplatform=generic && \
     meson configure -Ddisable_apps=* && \
     meson configure -Dtests=false && \
     meson configure -Ddisable_drivers=baseband/*,event/*,raw/* && \

--- a/ubuntu_20.04-arm64-native-dpdk_21.11/Dockerfile
+++ b/ubuntu_20.04-arm64-native-dpdk_21.11/Dockerfile
@@ -44,7 +44,6 @@ RUN cd $HOME && \
     cd dpdk && \
     meson setup build && \
     cd build && \
-    meson configure -Dplatform=generic && \
     meson configure -Ddisable_apps=* && \
     meson configure -Dtests=false && \
     meson configure -Denable_drivers=crypto/*,dma/*,mempool/ring,net/pcap && \

--- a/ubuntu_20.04-arm64-native-dpdk_22.11/Dockerfile
+++ b/ubuntu_20.04-arm64-native-dpdk_22.11/Dockerfile
@@ -43,7 +43,6 @@ RUN cd $HOME && \
     cd dpdk && \
     meson setup build && \
     cd build && \
-    meson configure -Dplatform=generic && \
     meson configure -Ddisable_apps=* && \
     meson configure -Dtests=false && \
     meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \

--- a/ubuntu_20.04-arm64-native/Dockerfile
+++ b/ubuntu_20.04-arm64-native/Dockerfile
@@ -54,7 +54,6 @@ RUN cd $HOME && \
     cd dpdk && \
     meson setup build && \
     cd build && \
-    meson configure -Dplatform=generic && \
     meson configure -Ddisable_apps=* && \
     meson configure -Dtests=false && \
     meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \

--- a/ubuntu_22.04-arm64-native/Dockerfile
+++ b/ubuntu_22.04-arm64-native/Dockerfile
@@ -57,7 +57,6 @@ RUN cd $HOME && \
     cd dpdk && \
     meson setup build && \
     cd build && \
-    meson configure -Dplatform=generic && \
     meson configure -Ddisable_apps=* && \
     meson configure -Dtests=false && \
     meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \

--- a/ubuntu_23.04-arm64-native/Dockerfile
+++ b/ubuntu_23.04-arm64-native/Dockerfile
@@ -46,7 +46,6 @@ RUN cd $HOME && \
     cd dpdk && \
     meson setup build && \
     cd build && \
-    meson configure -Dplatform=generic && \
     meson configure -Ddisable_apps=* && \
     meson configure -Dtests=false && \
     meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \


### PR DESCRIPTION
Generic platform DPDK option adds '-moutline-atomics' flag, which breaks ODP CI clang build jobs.