### PR TITLE
ubuntu_22.04: install ML dependencies

### DIFF
--- a/ubuntu_22.04-arm64-native/Dockerfile
+++ b/ubuntu_22.04-arm64-native/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:22.04
 ENV DPDK_VERSION=v22.11.3 \
     IPSEC_MB_VERSION=SECLIB-IPSEC-2022.12.13 \
     XDP_VERSION=v1.2.3 \
-    AARCH64_CRYPTOLIB_TAG=2445f0e
+    AARCH64_CRYPTOLIB_TAG=2445f0e \
+    ONNX_VERSION=1.16.3
 
 RUN apt-get update
 
@@ -47,10 +48,19 @@ RUN apt-get install -yy \
   net-tools \
   ninja-build \
   python3-pip \
-  sudo
+  sudo \
+  wget
 
 RUN pip3 install \
+  numpy \
+  onnx \
   pyelftools
+
+RUN cd /usr/local && \
+    wget -O - \
+        https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-aarch64-${ONNX_VERSION}.tgz | \
+        tar zx --strip-components=1 --wildcards "*/include" "*/lib" && \
+    ldconfig
 
 RUN cd $HOME && \
     git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \

--- a/ubuntu_22.04-x86_64/Dockerfile
+++ b/ubuntu_22.04-x86_64/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:22.04
 
 ENV DPDK_VERSION=v22.11.3 \
-    XDP_VERSION=v1.2.3
+    XDP_VERSION=v1.2.3 \
+    ONNX_VERSION=1.16.3
 
 RUN apt-get update
 
@@ -44,10 +45,19 @@ RUN apt-get install -yy \
   net-tools \
   ninja-build \
   python3-pip \
-  sudo
+  sudo \
+  wget
 
 RUN pip3 install \
+  numpy \
+  onnx \
   pyelftools
+
+RUN cd /usr/local && \
+    wget -O - \
+        https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-x64-${ONNX_VERSION}.tgz | \
+        tar zx --strip-components=1 --wildcards "*/include" "*/lib" && \
+    ldconfig
 
 RUN cd $HOME && \
     git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \


### PR DESCRIPTION
For machine learning support, install ONNX Runtime library (https://github.com/microsoft/onnxruntime), and onnx and numpy python packages.