### PR TITLE
ubuntu_20.04: replace default clang on graviton3

### DIFF
--- a/ubuntu_20.04-arm64-graviton3/Dockerfile
+++ b/ubuntu_20.04-arm64-graviton3/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get install -yy \
   autoconf \
   automake \
   ccache \
-  clang \
   clang-12 \
   gcc \
   gcc-10 \
@@ -45,6 +44,10 @@ RUN apt-get install -yy \
   ruby-dev \
   sudo \
   xsltproc
+
+RUN cd /usr/bin && \
+  ln -s ../lib/llvm-12/bin/clang clang && \
+  ln -s ../lib/llvm-12/bin/clang++ clang++ 
 
 RUN pip3 install \
   coverage \


### PR DESCRIPTION
Clang 12 includes support for Neoverse V1 CPU.