### PR TITLE
Update runners

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -38,6 +38,7 @@ jobs:
                 'ubuntu_22.04-x86_64-static',
                 'ubuntu_24.04-arm64',
                 'ubuntu_24.04-ppc64el',
+                'ubuntu_24.04-riscv64',
                 'ubuntu_24.04-x86_64',
                 'rocky_linux_8-x86_64',
                 'rocky_linux_9-x86_64']

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ['ubuntu_18.04-i386',
+        image: ['debian_12-i386',
+                'ubuntu_18.04-i386',
                 'ubuntu_20.04-arm64',
                 'ubuntu_20.04-armhf',
                 'ubuntu_20.04-ppc64el',

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -36,6 +36,7 @@ jobs:
                 'ubuntu_20.04-x86_64-dpdk_23.11',
                 'ubuntu_22.04-x86_64',
                 'ubuntu_22.04-x86_64-static',
+                'ubuntu_24.04-arm64',
                 'ubuntu_24.04-x86_64',
                 'rocky_linux_8-x86_64',
                 'rocky_linux_9-x86_64']

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -37,6 +37,7 @@ jobs:
                 'ubuntu_22.04-x86_64',
                 'ubuntu_22.04-x86_64-static',
                 'ubuntu_24.04-arm64',
+                'ubuntu_24.04-ppc64el',
                 'ubuntu_24.04-x86_64',
                 'rocky_linux_8-x86_64',
                 'rocky_linux_9-x86_64']

--- a/debian_12-i386/Dockerfile
+++ b/debian_12-i386/Dockerfile
@@ -1,0 +1,63 @@
+FROM i386/debian:12
+
+ENV DPDK_VERSION=v22.11.6
+
+RUN apt-get update
+
+RUN apt-get install -yy --no-install-recommends \
+        software-properties-common \
+	dirmngr \
+	gnupg-agent
+
+RUN rm -f /etc/apt/sources.list.d/debian.sources
+
+RUN [ -f /etc/apt/sources.list ] || echo "deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware" > /etc/apt/sources.list
+
+RUN dpkg --add-architecture i386
+
+RUN sed -e 's/^deb /deb [arch=amd64,i386] /g' /etc/apt/sources.list -i
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -yy \
+  libcli-dev:i386 \
+  libconfig-dev:i386 \
+  libcunit1-dev:i386 \
+  libpcap-dev:i386 \
+  libssl-dev:i386 \
+  g++-multilib \
+  autoconf \
+  automake \
+  ccache \
+  clang \
+  gcc \
+  gcc-multilib \
+  g++-multilib \
+  git \
+  iproute2 \
+  kmod \
+  libtool \
+  net-tools \
+  ninja-build \
+  python3-pip \
+  sudo \
+  meson \
+  python3-pyelftools \
+  libsystemd-dev
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu/pkgconfig \
+    meson setup -Dc_args='-m32' -Dc_link_args='-m32' build && \
+    cd build && \
+    meson configure -Dlibdir=lib/i386-linux-gnu && \
+    meson configure -Dmachine=default && \
+    meson configure -Dprefix=/usr && \
+    meson configure -Ddisable_apps=* && \
+    meson configure -Dtests=false && \
+    meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \
+    ninja install && \
+    ldconfig && \
+    cd $HOME && \
+    rm -r ./dpdk

--- a/rocky_linux_9-x86_64/Dockerfile
+++ b/rocky_linux_9-x86_64/Dockerfile
@@ -18,7 +18,7 @@ RUN yum install -y \
 	diffutils \
 	gcc \
 	gcc-c++ \
-	gcc-toolset-12-libatomic-devel \
+	gcc-toolset-13-libatomic-devel \
 	git-core \
 	kmod \
 	libatomic \

--- a/ubuntu_24.04-arm64/Dockerfile
+++ b/ubuntu_24.04-arm64/Dockerfile
@@ -1,0 +1,103 @@
+FROM ubuntu:24.04
+
+ENV DPDK_VERSION=v22.11.6 \
+    AARCH64_CRYPTOLIB_TAG=2445f0e
+
+RUN apt-get update
+
+RUN apt-get install -y --no-install-recommends \
+  software-properties-common \
+  dirmngr \
+  gnupg-agent
+
+RUN sed -e 's/^deb http/deb [arch=amd64] http/g' /etc/apt/sources.list -i
+
+RUN dpkg --add-architecture arm64
+
+RUN rm -f /etc/apt/sources.list.d/ubuntu.sources
+
+RUN cat <<EOF > /etc/apt/sources.list.d/ubuntu.sources
+# amd64 repositories (use archive.ubuntu.com and security.ubuntu.com)
+Types: deb
+URIs: http://archive.ubuntu.com/ubuntu/
+Suites: noble noble-updates noble-backports
+Components: main restricted universe multiverse
+Architectures: amd64
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: http://security.ubuntu.com/ubuntu/
+Suites: noble-security
+Components: main restricted universe multiverse
+Architectures: amd64
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+
+RUN cat <<EOF > /etc/apt/sources.list.d/ubuntu_arm64.sources
+# arm64 repositories (use ports.ubuntu.com)
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble noble-updates noble-backports
+Components: main restricted universe multiverse
+Architectures: arm64
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble-security
+Components: main restricted universe multiverse
+Architectures: arm64
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -y \
+  crossbuild-essential-arm64 \
+  libc6:arm64 \
+  libcli-dev:arm64 \
+  libconfig-dev:arm64 \
+  libcunit1-dev:arm64 \
+  libpcap-dev:arm64 \
+  libssl-dev:arm64 \
+  libstdc++-10-dev:arm64 \
+  autoconf \
+  automake \
+  ccache \
+  clang \
+  gcc \
+  gcc-10 \
+  git \
+  iproute2 \
+  kmod \
+  libtool \
+  meson \
+  net-tools \
+  ninja-build \
+  python3-pip \
+  python3-pyelftools \
+  sudo
+
+# '-moutline-atomics' removed to fix clang build
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    sed 's/-moutline-atomics//g' -i config/arm/meson.build && \
+    meson setup build --cross-file config/arm/arm64_armv8_linux_gcc && \
+    cd build && \
+    meson configure -Dlibdir=lib/aarch64-linux-gnu && \
+    meson configure -Dprefix=/usr && \
+    meson configure -Ddisable_apps=* && \
+    meson configure -Dtests=false && \
+    meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \
+    ninja install && \
+    ldconfig && \
+    cd $HOME && \
+    rm -r ./dpdk
+
+RUN cd $HOME && \
+    git clone https://github.com/ARM-software/AArch64cryptolib --depth 1 ./aarch64cryptolib && \
+    cd aarch64cryptolib && \
+    git checkout ${AARCH64_CRYPTOLIB_TAG} && \
+    make OPT=big CROSS=aarch64-linux-gnu- && \
+    cd -

--- a/ubuntu_24.04-ppc64el/Dockerfile
+++ b/ubuntu_24.04-ppc64el/Dockerfile
@@ -1,0 +1,93 @@
+FROM ubuntu:24.04
+
+ENV DPDK_VERSION=v22.11.6
+
+RUN apt-get update
+
+RUN apt-get install -y --no-install-recommends \
+  software-properties-common \
+  dirmngr \
+  gnupg-agent
+
+RUN sed -e 's/^deb http/deb [arch=amd64] http/g' /etc/apt/sources.list -i
+
+RUN dpkg --add-architecture ppc64el
+
+RUN rm -f /etc/apt/sources.list.d/ubuntu.sources
+
+RUN cat <<EOF > /etc/apt/sources.list.d/ubuntu.sources
+# amd64 repositories (use archive.ubuntu.com and security.ubuntu.com)
+Types: deb
+URIs: http://archive.ubuntu.com/ubuntu/
+Suites: noble noble-updates noble-backports
+Components: main restricted universe multiverse
+Architectures: amd64
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: http://security.ubuntu.com/ubuntu/
+Suites: noble-security
+Components: main restricted universe multiverse
+Architectures: amd64
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+
+RUN cat <<EOF > /etc/apt/sources.list.d/ubuntu_ppc64el.sources
+# ppc64el repositories (use ports.ubuntu.com)
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble noble-updates noble-backports
+Components: main restricted universe multiverse
+Architectures: ppc64el
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble-security
+Components: main restricted universe multiverse
+Architectures: ppc64el
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -y \
+  crossbuild-essential-ppc64el \
+  libc6:ppc64el \
+  libcli-dev:ppc64el \
+  libconfig-dev:ppc64el \
+  libcunit1-dev:ppc64el \
+  libpcap-dev:ppc64el \
+  libssl-dev:ppc64el \
+  libstdc++-10-dev:ppc64el \
+  autoconf \
+  automake \
+  ccache \
+  clang \
+  gcc \
+  gcc-10 \
+  git \
+  iproute2 \
+  kmod \
+  libtool \
+  meson \
+  net-tools \
+  ninja-build \
+  python3-pip \
+  python3-pyelftools \
+  sudo
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    meson setup build --cross-file config/ppc/ppc64le-power8-linux-gcc-ubuntu && \
+    cd build && \
+    meson configure -Dlibdir=lib/powerpc64le-linux-gnu && \
+    meson configure -Dprefix=/usr && \
+    meson configure -Ddisable_apps=* && \
+    meson configure -Dtests=false && \
+    meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \
+    ninja install && \
+    ldconfig && \
+    cd $HOME && \
+    rm -r ./dpdk

--- a/ubuntu_24.04-riscv64/Dockerfile
+++ b/ubuntu_24.04-riscv64/Dockerfile
@@ -1,0 +1,93 @@
+FROM ubuntu:24.04
+
+ENV DPDK_VERSION=v22.11.6
+
+RUN apt-get update
+
+RUN apt-get install -y --no-install-recommends \
+  software-properties-common \
+  dirmngr \
+  gnupg-agent
+
+RUN sed -e 's/^deb http/deb [arch=amd64] http/g' /etc/apt/sources.list -i
+
+RUN dpkg --add-architecture riscv64
+
+RUN rm -f /etc/apt/sources.list.d/ubuntu.sources
+
+RUN cat <<EOF > /etc/apt/sources.list.d/ubuntu.sources
+# amd64 repositories (use archive.ubuntu.com and security.ubuntu.com)
+Types: deb
+URIs: http://archive.ubuntu.com/ubuntu/
+Suites: noble noble-updates noble-backports
+Components: main restricted universe multiverse
+Architectures: amd64
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: http://security.ubuntu.com/ubuntu/
+Suites: noble-security
+Components: main restricted universe multiverse
+Architectures: amd64
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+
+RUN cat <<EOF > /etc/apt/sources.list.d/ubuntu_riscv64.sources
+# riscv64 repositories (use ports.ubuntu.com)
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble noble-updates noble-backports
+Components: main restricted universe multiverse
+Architectures: riscv64
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble-security
+Components: main restricted universe multiverse
+Architectures: riscv64
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+
+RUN apt-get update --fix-missing
+
+RUN apt-get install -y \
+  crossbuild-essential-riscv64 \
+  libc6:riscv64 \
+  libcli-dev:riscv64 \
+  libconfig-dev:riscv64 \
+  libcunit1-dev:riscv64 \
+  libpcap-dev:riscv64 \
+  libssl-dev:riscv64 \
+  libstdc++-10-dev:riscv64 \
+  autoconf \
+  automake \
+  ccache \
+  clang \
+  gcc \
+  gcc-10 \
+  git \
+  iproute2 \
+  kmod \
+  libtool \
+  meson \
+  net-tools \
+  ninja-build \
+  python3-pip \
+  python3-pyelftools \
+  sudo
+
+RUN cd $HOME && \
+    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    cd dpdk && \
+    meson setup build --cross-file config/riscv/riscv64_linux_gcc && \
+    cd build && \
+    meson configure -Dlibdir=lib/riscv64-linux-gnu && \
+    meson configure -Dprefix=/usr && \
+    meson configure -Ddisable_apps=* && \
+    meson configure -Dtests=false && \
+    meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \
+    ninja install && \
+    ldconfig && \
+    cd $HOME && \
+    rm -r ./dpdk

--- a/ubuntu_24.04-x86_64/Dockerfile
+++ b/ubuntu_24.04-x86_64/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get install -yy --no-install-recommends \
 RUN apt-get update --fix-missing
 
 RUN apt-get install -yy \
+  asciidoctor \
   autoconf \
   automake \
   ccache \
@@ -26,6 +27,7 @@ RUN apt-get install -yy \
   gcc-14 \
   gcc-multilib \
   git \
+  graphviz \
   iproute2 \
   kmod \
   libbpf-dev \
@@ -43,6 +45,7 @@ RUN apt-get install -yy \
   libtool \
   llvm-dev \
   meson \
+  mscgen \
   net-tools \
   ninja-build \
   python3-pip \


### PR DESCRIPTION
Update runners for:
- x86-64: install required tools in ubuntu 24.04
- rocky-9: remove rocky-8 and upgrade gcc libatomic 12 -> 13
- i386: change from ubuntu 18.04 to debian 12 for 32-bit LTS support
- arm64, ppc64el, riscv64: upgrade from ubuntu 20.04 to 24.04 for LTS support
