### PR TITLE
github_ci: update github hosted runners

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       IMAGE_DIR: ${{matrix.image}}
       IMAGE_NAME: odp-ci-${{matrix.image}}
@@ -125,7 +125,7 @@ jobs:
           docker push $IMAGE_ID:$VERSION
 
   Coverity:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COVERITY_TOKEN_ODP: ${{ secrets.COVERITY_TOKEN_ODP }}
       COVERITY_TOKEN_ODP_DPDK: ${{ secrets.COVERITY_TOKEN_ODP_DPDK }}


### PR DESCRIPTION
Update GitHub hosted runners from Ubuntu 20.04 to 22.04.