### PR TITLE
Update and fix containers

### DIFF
--- a/centos_7-x86_64/Dockerfile
+++ b/centos_7-x86_64/Dockerfile
@@ -56,7 +56,7 @@ RUN cd $HOME && \
     rm -r ./libconfig
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     make config T=x86_64-native-linuxapp-gcc O=x86_64-native-linuxapp-gcc && \
     cd x86_64-native-linuxapp-gcc/ && \

--- a/debian_12-i386/Dockerfile
+++ b/debian_12-i386/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get install -yy \
   python3-pyelftools
 
 RUN cd $HOME && \
-  git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+  git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
   cd dpdk && \
   PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu/pkgconfig \
   meson setup -Dc_args='-m32' -Dc_link_args='-m32' build && \

--- a/debian_12-i386/Dockerfile
+++ b/debian_12-i386/Dockerfile
@@ -1,11 +1,11 @@
-FROM i386/debian:12
+FROM debian:12
 
-ENV DPDK_VERSION=v22.11.6
+ENV DPDK_VERSION=v23.11.4
 
 RUN apt-get update
 
 RUN apt-get install -yy --no-install-recommends \
-        software-properties-common \
+  software-properties-common \
 	dirmngr \
 	gnupg-agent
 
@@ -17,14 +17,26 @@ RUN dpkg --add-architecture i386
 
 RUN sed -e 's/^deb /deb [arch=amd64,i386] /g' /etc/apt/sources.list -i
 
+RUN tee /etc/apt/sources.list <<EOF
+deb [arch=amd64,i386] http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb [arch=amd64,i386] http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb [arch=amd64,i386] http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+EOF
+
 RUN apt-get update --fix-missing
+
+RUN apt-get install -y --allow-downgrades perl-base=5.36.0-7+deb12u1
 
 RUN apt-get install -yy \
   libcli-dev:i386 \
   libconfig-dev:i386 \
   libcunit1-dev:i386 \
+  liblzma5:i386 \
+  libnuma-dev:i386 \
   libpcap-dev:i386 \
   libssl-dev:i386 \
+  libsystemd0:i386 \
+  libsystemd-dev:i386  \
   g++-multilib \
   autoconf \
   automake \
@@ -42,22 +54,21 @@ RUN apt-get install -yy \
   python3-pip \
   sudo \
   meson \
-  python3-pyelftools \
-  libsystemd-dev
+  python3-pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
-    cd dpdk && \
-    PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu/pkgconfig \
-    meson setup -Dc_args='-m32' -Dc_link_args='-m32' build && \
-    cd build && \
-    meson configure -Dlibdir=lib/i386-linux-gnu && \
-    meson configure -Dmachine=default && \
-    meson configure -Dprefix=/usr && \
-    meson configure -Ddisable_apps=* && \
-    meson configure -Dtests=false && \
-    meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \
-    ninja install && \
-    ldconfig && \
-    cd $HOME && \
-    rm -r ./dpdk
+  git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+  cd dpdk && \
+  PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu/pkgconfig \
+  meson setup -Dc_args='-m32' -Dc_link_args='-m32' build && \
+  cd build && \
+  meson configure -Dlibdir=lib/i386-linux-gnu && \
+  meson configure -Dmachine=default && \
+  meson configure -Dprefix=/usr && \
+  meson configure -Ddisable_apps=* && \
+  meson configure -Dtests=false && \
+  meson configure -Denable_drivers=crypto/*,dma/*,net/pcap && \
+  ninja install && \
+  ldconfig && \
+  cd $HOME && \
+  rm -r ./dpdk

--- a/rocky_linux_8-arm64-graviton3/Dockerfile
+++ b/rocky_linux_8-arm64-graviton3/Dockerfile
@@ -44,7 +44,7 @@ RUN pip3 install \
 	pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/rocky_linux_8-arm64-native/Dockerfile
+++ b/rocky_linux_8-arm64-native/Dockerfile
@@ -44,7 +44,7 @@ RUN pip3 install \
 	pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/rocky_linux_8-x86_64/Dockerfile
+++ b/rocky_linux_8-x86_64/Dockerfile
@@ -42,7 +42,7 @@ RUN pip3 install \
 	pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/rocky_linux_9-arm64-graviton3/Dockerfile
+++ b/rocky_linux_9-arm64-graviton3/Dockerfile
@@ -44,7 +44,7 @@ RUN pip3 install \
 	pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/rocky_linux_9-arm64-native/Dockerfile
+++ b/rocky_linux_9-arm64-native/Dockerfile
@@ -44,7 +44,7 @@ RUN pip3 install \
 	pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/rocky_linux_9-x86_64/Dockerfile
+++ b/rocky_linux_9-x86_64/Dockerfile
@@ -42,7 +42,7 @@ RUN pip3 install \
 	pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_18.04-arm64-native/Dockerfile
+++ b/ubuntu_18.04-arm64-native/Dockerfile
@@ -40,7 +40,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_18.04-arm64/Dockerfile
+++ b/ubuntu_18.04-arm64/Dockerfile
@@ -46,7 +46,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build --cross-file config/arm/arm64_armv8_linux_gcc && \
     cd build && \

--- a/ubuntu_18.04-i386/Dockerfile
+++ b/ubuntu_18.04-i386/Dockerfile
@@ -43,7 +43,7 @@ RUN pip3 install \
 	pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu/pkgconfig \
     meson setup -Dc_args='-m32' -Dc_link_args='-m32' build && \

--- a/ubuntu_18.04-x86_64/Dockerfile
+++ b/ubuntu_18.04-x86_64/Dockerfile
@@ -42,7 +42,7 @@ RUN pip3 install \
 	pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-arm64-graviton3-dpdk_19.11/Dockerfile
+++ b/ubuntu_20.04-arm64-graviton3-dpdk_19.11/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get install -yy \
   sudo
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     make config T=${RTE_TARGET} O=${RTE_TARGET} && \
     cd ${RTE_TARGET} && \

--- a/ubuntu_20.04-arm64-graviton3-dpdk_20.11/Dockerfile
+++ b/ubuntu_20.04-arm64-graviton3-dpdk_20.11/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get install -yy \
   sudo
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-arm64-graviton3-dpdk_21.11/Dockerfile
+++ b/ubuntu_20.04-arm64-graviton3-dpdk_21.11/Dockerfile
@@ -40,7 +40,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build -Dplatform=generic && \
     cd build && \

--- a/ubuntu_20.04-arm64-graviton3-dpdk_22.11/Dockerfile
+++ b/ubuntu_20.04-arm64-graviton3-dpdk_22.11/Dockerfile
@@ -39,7 +39,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-arm64-graviton3-dpdk_23.11/Dockerfile
+++ b/ubuntu_20.04-arm64-graviton3-dpdk_23.11/Dockerfile
@@ -40,7 +40,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-arm64-graviton3/Dockerfile
+++ b/ubuntu_20.04-arm64-graviton3/Dockerfile
@@ -54,7 +54,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-arm64-native-dpdk_19.11/Dockerfile
+++ b/ubuntu_20.04-arm64-native-dpdk_19.11/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get install -yy \
   sudo
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     make config T=${RTE_TARGET} O=${RTE_TARGET} && \
     cd ${RTE_TARGET} && \

--- a/ubuntu_20.04-arm64-native-dpdk_20.11/Dockerfile
+++ b/ubuntu_20.04-arm64-native-dpdk_20.11/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get install -yy \
   sudo
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-arm64-native-dpdk_21.11/Dockerfile
+++ b/ubuntu_20.04-arm64-native-dpdk_21.11/Dockerfile
@@ -40,7 +40,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-arm64-native-dpdk_22.11/Dockerfile
+++ b/ubuntu_20.04-arm64-native-dpdk_22.11/Dockerfile
@@ -39,7 +39,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-arm64-native-dpdk_23.11/Dockerfile
+++ b/ubuntu_20.04-arm64-native-dpdk_23.11/Dockerfile
@@ -40,7 +40,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-arm64-native/Dockerfile
+++ b/ubuntu_20.04-arm64-native/Dockerfile
@@ -50,7 +50,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-arm64/Dockerfile
+++ b/ubuntu_20.04-arm64/Dockerfile
@@ -52,7 +52,7 @@ RUN pip3 install \
 
 # '-moutline-atomics' removed to fix clang build
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     sed 's/-moutline-atomics//g' -i config/arm/meson.build && \
     meson setup build --cross-file config/arm/arm64_armv8_linux_gcc && \

--- a/ubuntu_20.04-armhf/Dockerfile
+++ b/ubuntu_20.04-armhf/Dockerfile
@@ -49,7 +49,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build --cross-file config/arm/arm32_armv8_linux_gcc && \
     cd build && \

--- a/ubuntu_20.04-ppc64el/Dockerfile
+++ b/ubuntu_20.04-ppc64el/Dockerfile
@@ -49,7 +49,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build --cross-file config/ppc/ppc64le-power8-linux-gcc-ubuntu && \
     cd build && \

--- a/ubuntu_20.04-riscv64/Dockerfile
+++ b/ubuntu_20.04-riscv64/Dockerfile
@@ -50,7 +50,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build --cross-file config/riscv/riscv64_linux_gcc && \
     cd build && \

--- a/ubuntu_20.04-x86_64-coverity-linux-dpdk/Dockerfile
+++ b/ubuntu_20.04-x86_64-coverity-linux-dpdk/Dockerfile
@@ -41,7 +41,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-x86_64-dpdk_19.11/Dockerfile
+++ b/ubuntu_20.04-x86_64-dpdk_19.11/Dockerfile
@@ -46,7 +46,7 @@ RUN cd $HOME && \
     rm -r ./ipsec-mb
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     make config T=${RTE_TARGET} O=${RTE_TARGET} && \
     cd ${RTE_TARGET} && \

--- a/ubuntu_20.04-x86_64-dpdk_20.11/Dockerfile
+++ b/ubuntu_20.04-x86_64-dpdk_20.11/Dockerfile
@@ -45,7 +45,7 @@ RUN cd $HOME && \
     rm -r ./ipsec-mb
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-x86_64-dpdk_21.11/Dockerfile
+++ b/ubuntu_20.04-x86_64-dpdk_21.11/Dockerfile
@@ -48,7 +48,7 @@ RUN cd $HOME && \
     rm -r ./ipsec-mb
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-x86_64-dpdk_22.11/Dockerfile
+++ b/ubuntu_20.04-x86_64-dpdk_22.11/Dockerfile
@@ -48,7 +48,7 @@ RUN cd $HOME && \
     rm -r ./ipsec-mb
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-x86_64-dpdk_23.11/Dockerfile
+++ b/ubuntu_20.04-x86_64-dpdk_23.11/Dockerfile
@@ -49,7 +49,7 @@ RUN cd $HOME && \
     rm -r ./ipsec-mb
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_20.04-x86_64/Dockerfile
+++ b/ubuntu_20.04-x86_64/Dockerfile
@@ -59,7 +59,7 @@ RUN cd $HOME && \
     rm -r ./ipsec-mb
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_22.04-arm64-graviton3/Dockerfile
+++ b/ubuntu_22.04-arm64-graviton3/Dockerfile
@@ -63,7 +63,7 @@ RUN cd /usr/local && \
     ldconfig
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_22.04-arm64-native/Dockerfile
+++ b/ubuntu_22.04-arm64-native/Dockerfile
@@ -63,7 +63,7 @@ RUN cd /usr/local && \
     ldconfig
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_22.04-x86_64-static/Dockerfile
+++ b/ubuntu_22.04-x86_64-static/Dockerfile
@@ -42,7 +42,7 @@ RUN pip3 install \
   pyelftools
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_22.04-x86_64/Dockerfile
+++ b/ubuntu_22.04-x86_64/Dockerfile
@@ -60,7 +60,7 @@ RUN cd /usr/local && \
     ldconfig
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_24.04-arm64-graviton3-dpdk_22.11/Dockerfile
+++ b/ubuntu_24.04-arm64-graviton3-dpdk_22.11/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get install -yy \
   sudo
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_24.04-arm64-graviton3-dpdk_24.11/Dockerfile
+++ b/ubuntu_24.04-arm64-graviton3-dpdk_24.11/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get install -yy \
   sudo
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_24.04-arm64-graviton3/Dockerfile
+++ b/ubuntu_24.04-arm64-graviton3/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get install -yy \
   sudo
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_24.04-arm64/Dockerfile
+++ b/ubuntu_24.04-arm64/Dockerfile
@@ -80,7 +80,7 @@ RUN apt-get install -y \
 
 # '-moutline-atomics' removed to fix clang build
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     sed 's/-moutline-atomics//g' -i config/arm/meson.build && \
     meson setup build --cross-file config/arm/arm64_armv8_linux_gcc && \

--- a/ubuntu_24.04-ppc64el/Dockerfile
+++ b/ubuntu_24.04-ppc64el/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get install -y \
   sudo
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build --cross-file config/ppc/ppc64le-power8-linux-gcc-ubuntu && \
     cd build && \

--- a/ubuntu_24.04-riscv64/Dockerfile
+++ b/ubuntu_24.04-riscv64/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get install -y \
   sudo
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build --cross-file config/riscv/riscv64_linux_gcc && \
     cd build && \

--- a/ubuntu_24.04-x86_64-dpdk_22.11/Dockerfile
+++ b/ubuntu_24.04-x86_64-dpdk_22.11/Dockerfile
@@ -44,7 +44,7 @@ RUN cd $HOME && \
     rm -r ./ipsec-mb
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_24.04-x86_64-dpdk_24.11/Dockerfile
+++ b/ubuntu_24.04-x86_64-dpdk_24.11/Dockerfile
@@ -45,7 +45,7 @@ RUN cd $HOME && \
     rm -r ./ipsec-mb
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_24.04-x86_64/Dockerfile
+++ b/ubuntu_24.04-x86_64/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get install -yy \
   sudo
 
 RUN cd $HOME && \
-    git clone http://dpdk.org/git/dpdk-stable --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
+    git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \
     cd dpdk && \
     meson setup build && \
     cd build && \

--- a/ubuntu_24.04-x86_64/Dockerfile
+++ b/ubuntu_24.04-x86_64/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-ENV DPDK_VERSION=v22.11.6 \
+ENV DPDK_VERSION=v23.11.4 \
     XDP_VERSION=v1.2.3
 
 RUN apt-get update
@@ -33,6 +33,7 @@ RUN apt-get install -yy \
   libbpf-dev \
   libconfig-dev \
   libcunit1-dev \
+  libnuma-dev \
   libpcap-dev \
   libssl-dev \
   libstdc++-9-dev \


### PR DESCRIPTION
Updated DPDK version for x86 ubuntu 24.04 to v23.11.4

i386 container wasn't building successfully due to a mismatch in perl and perl-base version,
pinned for now. Also updated DPDK version for the i386 Debian 12 container, causing other changes and modifications to allow necessary libraries to be installed.

