### PR TITLE
rocky_8: fix ODP CI clang build

### DIFF
--- a/rocky_linux_8-arm64-graviton3/Dockerfile
+++ b/rocky_linux_8-arm64-graviton3/Dockerfile
@@ -20,7 +20,7 @@ RUN yum install -y \
 	diffutils \
 	gcc \
 	gcc-c++ \
-	gcc-toolset-13-libatomic-devel \
+	gcc-toolset-14-libatomic-devel \
 	git-core \
 	glibc-static \
 	kmod \

--- a/rocky_linux_8-arm64-native/Dockerfile
+++ b/rocky_linux_8-arm64-native/Dockerfile
@@ -20,7 +20,7 @@ RUN yum install -y \
 	diffutils \
 	gcc \
 	gcc-c++ \
-	gcc-toolset-13-libatomic-devel \
+	gcc-toolset-14-libatomic-devel \
 	git-core \
 	glibc-static \
 	kmod \

--- a/rocky_linux_8-x86_64/Dockerfile
+++ b/rocky_linux_8-x86_64/Dockerfile
@@ -19,7 +19,7 @@ RUN yum install -y \
 	diffutils \
 	gcc \
 	gcc-c++ \
-	gcc-toolset-13-libatomic-devel \
+	gcc-toolset-14-libatomic-devel \
 	git-core \
 	kmod \
 	libatomic \


### PR DESCRIPTION
Fix '__atomic_exchange_16 is not available' configure error in ODP CI.