### PR TITLE
ubuntu_24.04: add missing dependencies

### DIFF
--- a/ubuntu_24.04-arm64/Dockerfile
+++ b/ubuntu_24.04-arm64/Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get install -y \
   libpcap-dev:arm64 \
   libssl-dev:arm64 \
   libstdc++-10-dev:arm64 \
+  libsystemd-dev:arm64 \
   autoconf \
   automake \
   ccache \

--- a/ubuntu_24.04-x86_64/Dockerfile
+++ b/ubuntu_24.04-x86_64/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
 ENV DPDK_VERSION=v23.11.4 \
+    IPSEC_MB_VERSION=v1.5 \
     XDP_VERSION=v1.2.3 \
     ONNX_VERSION=1.16.3
 
@@ -48,6 +49,7 @@ RUN apt-get install -yy \
   llvm-dev \
   meson \
   mscgen \
+  nasm \
   net-tools \
   ninja-build \
   python3-pip \
@@ -60,6 +62,14 @@ RUN cd /usr/local && \
         https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-x64-${ONNX_VERSION}.tgz | \
         tar zx --strip-components=1 --wildcards "*/include" "*/lib" && \
     ldconfig
+
+RUN cd $HOME && \
+    git clone https://github.com/intel/intel-ipsec-mb.git --branch ${IPSEC_MB_VERSION} --depth 1 ./ipsec-mb && \
+    cd ipsec-mb && \
+    make -j $(nproc) && \
+    make install && \
+    cd $HOME && \
+    rm -r ./ipsec-mb
 
 RUN cd $HOME && \
     git clone https://github.com/DPDK/dpdk-stable.git --branch ${DPDK_VERSION} --depth 1 ./dpdk && \


### PR DESCRIPTION
Add missing dependencies for ODP-DPDK v1.48.0 upgrade.