### PR TITLE
ubuntu_26.04: install libjitterentropy3-dev package

### DIFF
--- a/ubuntu_26.04-arm64-graviton3/Dockerfile
+++ b/ubuntu_26.04-arm64-graviton3/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get install -yy \
   libcli-dev \
   libconfig-dev \
   libcunit1-dev \
+  libjitterentropy3-dev \
   libonnxruntime-dev \
   libpcap-dev \
   libssl-dev \

--- a/ubuntu_26.04-x86_64/Dockerfile
+++ b/ubuntu_26.04-x86_64/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get install -yy \
   libbpf-dev \
   libconfig-dev \
   libcunit1-dev \
+  libjitterentropy3-dev \
   libnuma-dev \
   libonnxruntime-dev \
   libpcap-dev \


### PR DESCRIPTION
libjitterentropy3-dev is required by DPDK.